### PR TITLE
remove line-ending specification

### DIFF
--- a/_backend/plant_service/_database/_init.ts
+++ b/_backend/plant_service/_database/_init.ts
@@ -8,7 +8,6 @@ connection = require('../../../_repository/_config').connection;
 connection.query(`LOAD DATA LOCAL INFILE "_backend/plant_service/data/families.csv" INTO TABLE plant_families \
                  FIELDS TERMINATED BY ',' \
                  OPTIONALLY ENCLOSED BY '"' \
-                 LINES TERMINATED BY '\r\n' \
                  IGNORE 1 LINES;`
     , (err: any) => {
       if (err) throw err;
@@ -16,7 +15,6 @@ connection.query(`LOAD DATA LOCAL INFILE "_backend/plant_service/data/families.c
       connection.query(`LOAD DATA LOCAL INFILE "_backend/plant_service/data/plant_varieties.csv" INTO TABLE plant_varieties \
                  FIELDS TERMINATED BY ',' \
                  OPTIONALLY ENCLOSED BY '"' \
-                 LINES TERMINATED BY '\r\n' \
                  IGNORE 1 LINES;`
         , (err: any) => {
           if (err) throw err;


### PR DESCRIPTION
@amirhar, your fix in 154d39cbb6466495c9c410efada3f82e0e9129c3 broke the database for my setup -- I just removed the `LINES_TERMINATED_BY` argument altogether during database initialization.  Can you check that this also works for you please?